### PR TITLE
Improve occupation-skill-relation-converter performance

### DIFF
--- a/src/jobtech_taxonomy_database/converters/occupation_skill_relation_converter.clj
+++ b/src/jobtech_taxonomy_database/converters/occupation_skill_relation_converter.clj
@@ -4,25 +4,31 @@
             [jobtech-taxonomy-database.converters.converter-util :as u]
             [jobtech-taxonomy-database.types :as t]))
 
-(defn convert-ssyk-4-skill
-  [{:keys [skill-id ssyk-4-id]}]
-  {:pre [skill-id ssyk-4-id]}
-  (let [temp-id-ssyk (u/get-entity-if-exists-or-temp-id ssyk-4-id t/ssyk-level-4)
-        temp-id-skill (u/get-entity-if-exists-or-temp-id skill-id t/skill)
-        relation (u/create-relation temp-id-ssyk temp-id-skill t/related)]
-    relation))
+(defn convert-ssyk-4-skills []
+  (let [ssyk-4-skills (lm/fetch-data lm/get-ssyk-4-skill-relation)
+        ssyk-4-ids (u/type+legacy-ids->entity-ids-or-temp-ids t/ssyk-level-4 (map :ssyk-4-id ssyk-4-skills))
+        skill-ids (u/type+legacy-ids->entity-ids-or-temp-ids t/skill (map :skill-id ssyk-4-skills))]
+    ssyk-4-ids
+    skill-ids
+    (map (fn [{:keys [skill-id ssyk-4-id]}]
+           (u/create-relation
+            (get ssyk-4-ids (str ssyk-4-id))
+            (get skill-ids (str skill-id))
+            t/related))
+         ssyk-4-skills)))
 
-(defn convert-isco-4-skill
-  [{:keys [skill-id isco-4-id]}]
-  {:pre [skill-id isco-4-id]}
-  (let [temp-id-isco (u/get-entity-if-exists-or-temp-id isco-4-id t/isco-level-4)
-        temp-id-skill (u/get-entity-if-exists-or-temp-id skill-id t/skill)
-        relation (u/create-relation temp-id-isco temp-id-skill t/related)]
-    relation))
+(defn convert-isco-4-skills []
+  (let [isco-4-skills (lm/fetch-data lm/get-isco-4-skill-relation)
+        isco-4-ids (u/type+legacy-ids->entity-ids-or-temp-ids t/isco-level-4 (map :isco-4-id isco-4-skills))
+        skill-ids (u/type+legacy-ids->entity-ids-or-temp-ids t/skill (map :skill-id isco-4-skills))]
+    (map (fn [{:keys [skill-id isco-4-id]}]
+           (u/create-relation
+            (get isco-4-ids (str isco-4-id))
+            (get skill-ids (str skill-id))
+            t/related))
+         isco-4-skills)))
 
-(defn convert
-  ""
-  []
+(defn convert []
   (concat
-   (map convert-ssyk-4-skill (lm/fetch-data lm/get-ssyk-4-skill-relation))
-   (map convert-isco-4-skill (lm/fetch-data lm/get-isco-4-skill-relation))))
+   (convert-ssyk-4-skills)
+   (convert-isco-4-skills)))

--- a/src/jobtech_taxonomy_database/core.clj
+++ b/src/jobtech_taxonomy_database/core.clj
@@ -21,10 +21,6 @@
     jobtech-taxonomy-database.converters.occupation-converter
     jobtech-taxonomy-database.converters.skills-converter
     jobtech-taxonomy-database.converters.occupation-experience-year-converter
-    ;; TODO next converter seems to be unnecessary slow because it first fetches
-    ;; relations and then for every relation it runs a separate query
-    ;; looking up legacy id. Batching those queries might bring a significant
-    ;; speedup
     jobtech-taxonomy-database.converters.occupation-skill-relation-converter
     jobtech-taxonomy-database.converters.SNI-level-converter
     jobtech-taxonomy-database.converters.wage-type-converter


### PR DESCRIPTION
Previous implementation suffered from N+1 problem: for every relation, it made a separate request to find out whether it already exists in a database or not. Using a single query for all skills at once reduced execution time from around 10 minutes to around 5 seconds.