### PR TITLE
Migrate Sökandekategori / SKAT codes from the old taxonomy

### DIFF
--- a/src/jobtech_taxonomy_database/converters/unemployment_type.clj
+++ b/src/jobtech_taxonomy_database/converters/unemployment_type.clj
@@ -1,0 +1,18 @@
+(ns jobtech-taxonomy-database.converters.unemployment-type
+  (:gen-class)
+  (:require [jobtech-taxonomy-database.legacy-migration :as lm]
+            [jobtech-taxonomy-database.converters.converter-util :as u]
+            [jobtech-taxonomy-database.types :as t]))
+
+(defn convert-unemployment-type
+  "Convert a Swedish unemployment type"
+  [{:keys [sökandekategoriid beteckning]}]
+  {:pre [sökandekategoriid beteckning]}
+  (u/create-concept
+   t/unemployment-type beteckning beteckning sökandekategoriid))
+
+(defn convert
+  "Query db for unemployment types (SKAT codes)"
+  []
+  (concat (map convert-unemployment-type
+               (lm/fetch-data lm/get-skat-code))))

--- a/src/jobtech_taxonomy_database/core.clj
+++ b/src/jobtech_taxonomy_database/core.clj
@@ -26,6 +26,7 @@
     jobtech-taxonomy-database.converters.occupation-skill-relation-converter
     jobtech-taxonomy-database.converters.SNI-level-converter
     jobtech-taxonomy-database.converters.unemployment-fund
+    jobtech-taxonomy-database.converters.unemployment-type
     jobtech-taxonomy-database.converters.wage-type-converter
     jobtech-taxonomy-database.converters.worktime-extent-converter
 

--- a/src/jobtech_taxonomy_database/sql/legacy-taxonomy.sql
+++ b/src/jobtech_taxonomy_database/sql/legacy-taxonomy.sql
@@ -1,3 +1,13 @@
+---------------------------------------------------- SKAT CODES ---------------------------------------------------
+
+-- A ":result" value of ":*" specifies a vector of records
+-- (as hashmaps) will be returned
+-- :name get-skat-code :*
+-- :doc Get all codes for the categories a job applicant can be in, e.g.
+-- unemployed, partly unemployed, trainee, etc.
+SELECT sökandekategoriID, beteckning
+FROM TaxonomiDBSvensk.dbo.SökandekategoriTerm;
+
 ---------------------------------------------------- UNEMPLOYMENT FUNDS -------------------------------------------
 
 -- A ":result" value of ":*" specifies a vector of records

--- a/src/jobtech_taxonomy_database/types.clj
+++ b/src/jobtech_taxonomy_database/types.clj
@@ -38,6 +38,7 @@
 (def sun-education-level-2 "sun-education-level-2")
 (def sun-education-level-3 "sun-education-level-3")
 (def unemployment-fund "unemployment-fund")
+(def unemployment-type "unemployment-type")
 (def wage-type "wage-type")
 (def worktime-extent "worktime-extent")
 (def occupation-experience-year "occupation-experience-year")
@@ -57,6 +58,7 @@
                          sni-level-1
                          sni-level-2
                          unemployment-fund
+                         unemployment-type
                          wage-type
                          worktime-extent
                          isco-level-4                       ;previously OccupationGroup
@@ -121,6 +123,7 @@
              ["sun-education-level-2"],
              ["sun-education-level-3"],
              ["unemployment-fund"],
+             ["unemployment-type"],
              ["wage-type"],
              ["worktime-extent"]])
 


### PR DESCRIPTION
Fixes issue #154 https://gitlab.com/team-batfish/jobtech-taxonomy-api/-/issues/154.

There are two almost identical fields in the old database; beteckning
and beteckningFörSökande. beteckningFörSökande is used in less than
10% of the cases, and is pretty much an identical copy of beteckning.
This field is therefore not migrated to the new database. The
modification date is also not migrated.